### PR TITLE
Command execution time for each migration / rollback and total execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Added
 - support for yaml and neon configs
+- command execution time for each migration / rollback and total execution time
 
 #### Updated
 - composer libraries

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -71,7 +71,11 @@ abstract class AbstractCommand extends Command
         $this->manager = new Manager($this->config, $this->adapter);
         $this->check($input, $output);
         
+        $start = microtime(true);
         $this->runCommand($input, $output);
+        $output->writeln('');
+        $output->write('<comment>All done. Took ' . sprintf('%.4fs', microtime(true) - $start) . '</comment>');
+        $output->writeln('');
     }
     
     private function loadConfig(InputInterface $input)

--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -40,6 +40,5 @@ class CreateCommand extends AbstractCommand
         
         $output->writeln('');
         $output->writeln('<info>Migration "' . $migration . '" created</info>');
-        $output->writeln('');
     }
 }

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -28,6 +28,5 @@ class InitCommand extends AbstractCommand
         $output->writeln('<info>Phoenix initialized</info>');
         $output->writeln('Executed queries:', OutputInterface::VERBOSITY_DEBUG);
         $output->writeln($migration->getExecutedQueries(), OutputInterface::VERBOSITY_DEBUG);
-        $output->writeln('');
     }
 }

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -21,19 +21,21 @@ class MigrateCommand extends AbstractCommand
         if (empty($migrations)) {
             $output->writeln('');
             $output->writeln('<info>Nothing to migrate</info>');
-            $output->writeln('');
             return;
         }
         
         foreach ($migrations as $migration) {
+            $output->writeln('');
+            $output->writeln('<info>Migration ' . $migration->getClassName() . ' executing</info>');
+
+            $start = microtime(true);
             $migration->migrate();
+            $output->writeln('<info>Migration ' . $migration->getClassName() . ' executed</info>. <comment>Took ' . sprintf('%.4fs', microtime(true) - $start) . '</comment>');
+
             $this->manager->logExecution($migration);
             
-            $output->writeln('');
-            $output->writeln('<info>Migration ' . $migration->getClassName() . ' executed</info>');
             $output->writeln('Executed queries:', OutputInterface::VERBOSITY_DEBUG);
             $output->writeln($migration->getExecutedQueries(), OutputInterface::VERBOSITY_DEBUG);
         }
-        $output->writeln('');
     }
 }

--- a/src/Command/RollbackCommand.php
+++ b/src/Command/RollbackCommand.php
@@ -22,19 +22,21 @@ class RollbackCommand extends AbstractCommand
         if (empty($migrations)) {
             $output->writeln('');
             $output->writeln('<info>Nothing to rollback</info>');
-            $output->writeln('');
             return;
         }
         
         foreach ($migrations as $migration) {
+            $output->writeln('');
+            $output->writeln('<info>Rollback for migration ' . $migration->getClassName() . ' executing</info>');
+            
+            $start = microtime(true);
             $migration->rollback();
+            $output->writeln('<info>Rollback for migration ' . $migration->getClassName() . ' executed</info>. <comment>Took ' . sprintf('%.4fs', microtime(true) - $start) . '</comment>');
+
             $this->manager->removeExecution($migration);
             
-            $output->writeln('');
-            $output->writeln('<info>Rollback for migration ' . $migration->getClassName() . ' executed</info>');
             $output->writeln('Executed queries:', OutputInterface::VERBOSITY_DEBUG);
             $output->writeln($migration->getExecutedQueries(), OutputInterface::VERBOSITY_DEBUG);
-            $output->writeln('');
         }
     }
 }

--- a/src/Migration/AbstractMigration.php
+++ b/src/Migration/AbstractMigration.php
@@ -77,7 +77,7 @@ abstract class AbstractMigration
      */
     final public function getClassName()
     {
-        return $this->className;
+        return ltrim($this->className, '\\');
     }
     
     /**


### PR DESCRIPTION
- removed slash from the begining of class name
