### PR TITLE
Keep releases lean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto eol=lf
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+CHANGELOG.md export-ignore
+docs/ export-ignore
+example/ export-ignore
+humbug.json.dist export-ignore
+LICENSE export-ignore
+phpunit.xml.dist export-ignore
+README.md export-ignore
+testing_migrations/ export-ignore
+tests/ export-ignore


### PR DESCRIPTION
Excludes unnecessary files from releases/distributions. The `docs` and `example` directories and the `LICENSE` file might be excluded from that list of files, but that's up to your liking.