### PR TITLE
Added PHPStorm meta

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -113,7 +113,6 @@ namespace PHPSTORM_META
 
     registerArgumentsSet(
         'phoenix_index_types',
-
         \Phoenix\Database\Element\Index::TYPE_UNIQUE,
         \Phoenix\Database\Element\Index::TYPE_FULLTEXT,
         \Phoenix\Database\Element\Index::TYPE_NORMAL,

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace PHPSTORM_META
+{
+    registerArgumentsSet(
+        'phoenix_column_types',
+        'integer',
+        'string',
+        'text',
+        'boolean',
+        'char',
+        'datetime',
+        'date',
+        'time',
+        'timestamp',
+        'uuid',
+        'json',
+        'decimal',
+        'numeric',
+        'float',
+        'double',
+        'enum',
+        'set',
+        'tinyinteger',
+        'smallinteger',
+        'mediuminteger',
+        'biginteger',
+        'tinytext',
+        'mediumtext',
+        'longtext',
+        'tinyblob',
+        'mediumblob',
+        'blob',
+        'longblob',
+        'binary',
+        'varbinary',
+        'point',
+        'line',
+        'polygon',
+        \Phoenix\Database\Element\Column::TYPE_INTEGER,
+        \Phoenix\Database\Element\Column::TYPE_STRING,
+        \Phoenix\Database\Element\Column::TYPE_TEXT,
+        \Phoenix\Database\Element\Column::TYPE_BOOLEAN,
+        \Phoenix\Database\Element\Column::TYPE_CHAR,
+        \Phoenix\Database\Element\Column::TYPE_DATETIME,
+        \Phoenix\Database\Element\Column::TYPE_DATE,
+        \Phoenix\Database\Element\Column::TYPE_TIME,
+        \Phoenix\Database\Element\Column::TYPE_TIMESTAMP,
+        \Phoenix\Database\Element\Column::TYPE_UUID,
+        \Phoenix\Database\Element\Column::TYPE_JSON,
+        \Phoenix\Database\Element\Column::TYPE_DECIMAL,
+        \Phoenix\Database\Element\Column::TYPE_NUMERIC,
+        \Phoenix\Database\Element\Column::TYPE_FLOAT,
+        \Phoenix\Database\Element\Column::TYPE_DOUBLE,
+        \Phoenix\Database\Element\Column::TYPE_ENUM,
+        \Phoenix\Database\Element\Column::TYPE_SET,
+        \Phoenix\Database\Element\Column::TYPE_TINY_INTEGER,
+        \Phoenix\Database\Element\Column::TYPE_SMALL_INTEGER,
+        \Phoenix\Database\Element\Column::TYPE_MEDIUM_INTEGER,
+        \Phoenix\Database\Element\Column::TYPE_BIG_INTEGER,
+        \Phoenix\Database\Element\Column::TYPE_TINY_TEXT,
+        \Phoenix\Database\Element\Column::TYPE_MEDIUM_TEXT,
+        \Phoenix\Database\Element\Column::TYPE_LONG_TEXT,
+        \Phoenix\Database\Element\Column::TYPE_TINY_BLOB,
+        \Phoenix\Database\Element\Column::TYPE_MEDIUM_BLOB,
+        \Phoenix\Database\Element\Column::TYPE_BLOB,
+        \Phoenix\Database\Element\Column::TYPE_LONG_BLOB,
+        \Phoenix\Database\Element\Column::TYPE_BINARY,
+        \Phoenix\Database\Element\Column::TYPE_VARBINARY,
+        \Phoenix\Database\Element\Column::TYPE_POINT,
+        \Phoenix\Database\Element\Column::TYPE_LINE,
+        \Phoenix\Database\Element\Column::TYPE_POLYGON
+    );
+
+    expectedArguments(
+        \Phoenix\Database\Element\MigrationTable::addColumn(),
+        1,
+        argumentsSet('phoenix_column_types')
+    );
+
+    registerArgumentsSet('phoenix_column_settings', [
+        'null' => true, // default value = false / type = bool
+        'default' => null, // default value = null / type = int
+        'length' => null, // default value = null / type = int
+        'decimals' => null, // default value = null / type = int
+        'autoincrement' => false, // default value = false / type = bool
+        'signed' => true, // default value = true / type = bool
+        'after' => null, // default value = null / type = string
+        'first' => false, // default value = false / type = bool
+        'charset' => null, // default value = null / type = string
+        'collation' => null, // default value = null / type = string
+        'comment' => null, // default value = null / type = string
+        'values' => null, // default value = null / type = array
+        \Phoenix\Database\Element\ColumnSettings::SETTING_NULL => true, // default value = false / type = bool
+        \Phoenix\Database\Element\ColumnSettings::SETTING_DEFAULT => null, // default value = null / type = int
+        \Phoenix\Database\Element\ColumnSettings::SETTING_LENGTH => null, // default value = null / type = int
+        \Phoenix\Database\Element\ColumnSettings::SETTING_DECIMALS => null, // default value = null / type = int
+        \Phoenix\Database\Element\ColumnSettings::SETTING_AUTOINCREMENT => false, // default value = false / type = bool
+        \Phoenix\Database\Element\ColumnSettings::SETTING_SIGNED => true, // default value = true / type = bool
+        \Phoenix\Database\Element\ColumnSettings::SETTING_AFTER => null, // default value = null / type = string
+        \Phoenix\Database\Element\ColumnSettings::SETTING_FIRST => false, // default value = false / type = bool
+        \Phoenix\Database\Element\ColumnSettings::SETTING_CHARSET => null, // default value = null / type = string
+        \Phoenix\Database\Element\ColumnSettings::SETTING_COLLATION => null, // default value = null / type = string
+        \Phoenix\Database\Element\ColumnSettings::SETTING_COMMENT => null, // default value = null / type = string
+        \Phoenix\Database\Element\ColumnSettings::SETTING_VALUES => null // default value = null / type = array
+    ]);
+
+    expectedArguments(
+        \Phoenix\Database\Element\MigrationTable::addColumn(),
+        2,
+        argumentsSet('phoenix_column_settings')
+    );
+
+    registerArgumentsSet(
+        'phoenix_index_types',
+
+        \Phoenix\Database\Element\Index::TYPE_UNIQUE,
+        \Phoenix\Database\Element\Index::TYPE_FULLTEXT,
+        \Phoenix\Database\Element\Index::TYPE_NORMAL,
+        'UNIQUE',
+        'FULLTEXT',
+        'unique',
+        'fulltext',
+        '',
+    );
+
+    expectedArguments(
+        \Phoenix\Database\Element\Behavior\IndexBehavior::addIndex(),
+        1,
+        argumentsSet('phoenix_index_types')
+    );
+
+    registerArgumentsSet(
+        'phoenix_index_methods',
+        \Phoenix\Database\Element\Index::METHOD_BTREE,
+        \Phoenix\Database\Element\Index::METHOD_HASH,
+        \Phoenix\Database\Element\Index::METHOD_DEFAULT,
+        'BTREE',
+        'HASH',
+        'btree',
+        'hash',
+        ''
+    );
+    expectedArguments(
+        \Phoenix\Database\Element\Behavior\IndexBehavior::addIndex(),
+        2,
+        argumentsSet('phoenix_index_methods')
+    );
+}

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -3,6 +3,23 @@
 namespace PHPSTORM_META
 {
     registerArgumentsSet(
+        'phoenix_table_primary_key',
+        true,
+        false,
+        'column_name',
+        null,
+        ['column1_name', 'column2_name'],
+        new \Phoenix\Database\Element\Column('column_name', 'column_type'),
+        [new \Phoenix\Database\Element\Column('column1_name', 'column1_type'), new \Phoenix\Database\Element\Column('column2_name', 'column2_type')]
+    );
+
+    expectedArguments(
+        \Phoenix\Migration\AbstractMigration::table(),
+        1,
+        argumentsSet('phoenix_table_primary_key')
+    );
+
+    registerArgumentsSet(
         'phoenix_column_types',
         'integer',
         'string',
@@ -91,18 +108,6 @@ namespace PHPSTORM_META
         'collation' => null, // default value = null / type = string
         'comment' => null, // default value = null / type = string
         'values' => null, // default value = null / type = array
-        \Phoenix\Database\Element\ColumnSettings::SETTING_NULL => true, // default value = false / type = bool
-        \Phoenix\Database\Element\ColumnSettings::SETTING_DEFAULT => null, // default value = null / type = int
-        \Phoenix\Database\Element\ColumnSettings::SETTING_LENGTH => null, // default value = null / type = int
-        \Phoenix\Database\Element\ColumnSettings::SETTING_DECIMALS => null, // default value = null / type = int
-        \Phoenix\Database\Element\ColumnSettings::SETTING_AUTOINCREMENT => false, // default value = false / type = bool
-        \Phoenix\Database\Element\ColumnSettings::SETTING_SIGNED => true, // default value = true / type = bool
-        \Phoenix\Database\Element\ColumnSettings::SETTING_AFTER => null, // default value = null / type = string
-        \Phoenix\Database\Element\ColumnSettings::SETTING_FIRST => false, // default value = false / type = bool
-        \Phoenix\Database\Element\ColumnSettings::SETTING_CHARSET => null, // default value = null / type = string
-        \Phoenix\Database\Element\ColumnSettings::SETTING_COLLATION => null, // default value = null / type = string
-        \Phoenix\Database\Element\ColumnSettings::SETTING_COMMENT => null, // default value = null / type = string
-        \Phoenix\Database\Element\ColumnSettings::SETTING_VALUES => null // default value = null / type = array
     ]);
 
     expectedArguments(
@@ -140,9 +145,40 @@ namespace PHPSTORM_META
         'hash',
         ''
     );
+
     expectedArguments(
         \Phoenix\Database\Element\Behavior\IndexBehavior::addIndex(),
         2,
         argumentsSet('phoenix_index_methods')
+    );
+
+    registerArgumentsSet(
+        'phoenix_foreign_key_actions',
+        \Phoenix\Database\Element\ForeignKey::CASCADE,
+        \Phoenix\Database\Element\ForeignKey::RESTRICT,
+        \Phoenix\Database\Element\ForeignKey::SET_NULL,
+        \Phoenix\Database\Element\ForeignKey::NO_ACTION,
+        \Phoenix\Database\Element\ForeignKey::DEFAULT_ACTION,
+        'CASCADE',
+        'RESTRICT',
+        'SET NULL',
+        'NO ACTION',
+        'cascade',
+        'restrict',
+        'set null',
+        'no action',
+        ''
+    );
+
+    expectedArguments(
+        \Phoenix\Database\Element\Behavior\ForeignKeyBehavior::addForeignKey(),
+        3,
+        argumentsSet('phoenix_foreign_key_actions')
+    );
+
+    expectedArguments(
+        \Phoenix\Database\Element\Behavior\ForeignKeyBehavior::addForeignKey(),
+        4,
+        argumentsSet('phoenix_foreign_key_actions')
     );
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 
 script:
     - mkdir -p build/logs
-    - composer outdated -D --strict --ignore symfony/console --ignore symfony/finder --ignore symfony/yaml
+    - composer outdated -D --strict --ignore symfony/console --ignore symfony/finder --ignore symfony/yaml --ignore ramsey/uuid
     - composer require squizlabs/php_codesniffer --dev
     - vendor/bin/phpcs src --standard=PSR2 -n
     - composer remove squizlabs/php_codesniffer --dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Added
 - Added method renameColumn() to migrations
-- Added PHPStorm meta
+- Added PHPStorm meta for better suggestions
 
 ### [1.2.0] - 2020-03-16
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Added
 - Added method renameColumn() to migrations
+- Added PHPStorm meta
 
 ### [1.2.0] - 2020-03-16
 #### Changed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Framework agnostic database migrations for PHP.
 - Namespaces in migration classes
 - Own migration templates
 - Easy integration to any PHP application
+- PHPStorm suggestions (works even better with deep-assoc-completion plugin)
 
 ## Supported adapters
 - MySql

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "nette/neon": "^2.3|^3.0",
         "symfony/yaml": "^3.1|^4.0",
         "phpunit/phpunit": ">7.2",
-        "ramsey/uuid": "^3.7"
+        "ramsey/uuid": "^3.7|^4.0"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/src/Database/Element/Behavior/PrimaryColumnsBehavior.php
+++ b/src/Database/Element/Behavior/PrimaryColumnsBehavior.php
@@ -15,6 +15,12 @@ trait PrimaryColumnsBehavior
 
     private $dataChunkSize;
 
+    /**
+     * @param Column[] $primaryColumns
+     * @param Closure|null $primaryColumnsValuesFunction
+     * @param int|null $dataChunkSize
+     * @return MigrationTable
+     */
     public function addPrimaryColumns(array $primaryColumns, ?Closure $primaryColumnsValuesFunction = null, ?int $dataChunkSize = null): MigrationTable
     {
         foreach ($primaryColumns as $primaryColumn) {


### PR DESCRIPTION
TODO
- [x] Add meta for ->table() - second parameter is mixed
- [x] Add meta for foreign key - onDelete and onUpdate parameters
- [x] something else?
- [x] Mention PHPStorm, PHPStorm meta and deep-assoc-completion plugin in readme
- [x] Create issue with description to deep-assoc-completion - what is from usage? I would like to add some comment, default value and type to setting keys - it is added as in tests folder but not working, string + constant with the same value in array - works for 