### PR TITLE
Adds possibility to use existing database connection (based on PDO)

### DIFF
--- a/config_example/phoenix.php
+++ b/config_example/phoenix.php
@@ -24,9 +24,14 @@ return [
         ],
         'custom_connection' => [
             'adapter' => 'mysql', // or pgsql
-            'connection' => new PDO('mysql:host=127.0.0.1;port=3306;dbname=mysql;charset=utf8', null, null, [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT // we not recommend to use silent error mode but for testing purpose that is ok
-            ])
+            'connection' => new class("example:") extends PDO {
+
+                public function __construct($dsn, $username = null, $passwd = null, $options = null)
+                {
+                    // this method here is just to disable PDO connection on class instance creation
+                }
+
+            }, // any object instance that is based on PDO can be used here
         ]
     ],
 ];

--- a/config_example/phoenix.php
+++ b/config_example/phoenix.php
@@ -13,6 +13,7 @@ return [
             'password' => '123',
             'db_name' => 'phoenix',
             'charset' => 'utf8', // optional
+            'connection' => null, // existing PDO instance that you need to be reused; use this or other parameters
         ],
         'pgsql' => [
             'adapter' => 'pgsql',
@@ -21,6 +22,7 @@ return [
             'password' => '123',
             'db_name' => 'phoenix',
             'charset' => 'utf8',
+            'connection' => null, // existing PDO instance that you need to be reused; use this or other parameters
         ],
     ],
 ];

--- a/config_example/phoenix.php
+++ b/config_example/phoenix.php
@@ -24,7 +24,9 @@ return [
         ],
         'custom_connection' => [
             'adapter' => 'mysql', // or pgsql
-            'connection' => new PDO('mysql://'), // or any instance that extends PDO and compatible with selected adapter
+            'connection' => new PDO('mysql:host=127.0.0.1;port=3306;dbname=mysql;charset=utf8', [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT // we not recommend to use silent error mode but for testing purpose that is ok
+            ])
         ]
     ],
 ];

--- a/config_example/phoenix.php
+++ b/config_example/phoenix.php
@@ -13,7 +13,6 @@ return [
             'password' => '123',
             'db_name' => 'phoenix',
             'charset' => 'utf8', // optional
-            'connection' => null, // existing PDO instance that you need to be reused; use this or other parameters
         ],
         'pgsql' => [
             'adapter' => 'pgsql',
@@ -22,7 +21,10 @@ return [
             'password' => '123',
             'db_name' => 'phoenix',
             'charset' => 'utf8',
-            'connection' => null, // existing PDO instance that you need to be reused; use this or other parameters
         ],
+        'custom_connection' => [
+            'adapter' => 'mysql', // or pgsql
+            'connection' => new PDO('mysql://'), // or any instance that extends PDO and compatible with selected adapter
+        ]
     ],
 ];

--- a/config_example/phoenix.php
+++ b/config_example/phoenix.php
@@ -24,7 +24,7 @@ return [
         ],
         'custom_connection' => [
             'adapter' => 'mysql', // or pgsql
-            'connection' => new PDO('mysql:host=127.0.0.1;port=3306;dbname=mysql;charset=utf8', [
+            'connection' => new PDO('mysql:host=127.0.0.1;port=3306;dbname=mysql;charset=utf8', null, null, [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT // we not recommend to use silent error mode but for testing purpose that is ok
             ])
         ]

--- a/src/Config/EnvironmentConfig.php
+++ b/src/Config/EnvironmentConfig.php
@@ -3,6 +3,7 @@
 namespace Phoenix\Config;
 
 use PDO;
+use Phoenix\Exception\ConfigException;
 
 class EnvironmentConfig
 {
@@ -64,15 +65,21 @@ class EnvironmentConfig
 
     /**
      * If user wish to reuse existing connection, connection can be passed as config parameter 'connection'
-     * and will be accessed from here.
+     * and will be accessed from here. Otherwise new PDO connection will be created.
      *
-     * At current moment only PDO based connections are supported. In future that can change.
-     *
-     * @return PDO|null
+     * @return PDO
+     * 
+     * @throws ConfigException
      */
-    public function getConnection(): ?PDO
+    public function getConnection(): PDO
     {
-        return $this->checkConfigValue('connection') && ($this->configuration['connection'] instanceof \PDO) ? $this->configuration['connection'] : null;
+        if ($this->checkConfigValue('connection')) {
+            if ($this->configuration['connection'] instanceof PDO) {
+                return $this->configuration['connection'];
+            }
+            throw new ConfigException('Connection instance must extend PDO class');
+        }
+        return new PDO($this->getDsn(), $this->getUsername(), $this->getPassword());
     }
 
     private function checkConfigValue(string $key): bool

--- a/src/Config/EnvironmentConfig.php
+++ b/src/Config/EnvironmentConfig.php
@@ -29,6 +29,12 @@ class EnvironmentConfig
         if ($this->checkConfigValue('dsn')) {
             return $this->configuration['dsn'];
         }
+        if (!$this->checkConfigValue('db_name')) {
+            throw new ConfigException('db_name is not set for environment');
+        }
+        if (!$this->checkConfigValue('host')) {
+            throw new ConfigException('host is not set for environment');
+        }
         $dsn = $this->configuration['adapter'] . ':dbname=' . $this->configuration['db_name'] . ';host=' . $this->configuration['host'];
         if ($this->checkConfigValue('port')) {
             $dsn .= ';port=' . $this->configuration['port'];
@@ -68,7 +74,7 @@ class EnvironmentConfig
      * and will be accessed from here. Otherwise new PDO connection will be created.
      *
      * @return PDO
-     * 
+     *
      * @throws ConfigException
      */
     public function getConnection(): PDO

--- a/src/Config/EnvironmentConfig.php
+++ b/src/Config/EnvironmentConfig.php
@@ -60,6 +60,19 @@ class EnvironmentConfig
         return $this->configuration['version'] ?? null;
     }
 
+    /**
+     * If user wish to reuse existing connection, connection can be passed as config parameter 'connection'
+     * and will be accessed from here.
+     *
+     * At current moment only PDO based connections are supported. In future that can change.
+     *
+     * @return PDO|null
+     */
+    public function getConnection(): ?PDO
+    {
+        return $this->checkConfigValue('connection') && ($this->configuration['connection'] instanceof \PDO) ? $this->configuration['connection'] : null;
+    }
+
     private function checkConfigValue(string $key): bool
     {
         return isset($this->configuration[$key]) && $this->configuration[$key];

--- a/src/Config/EnvironmentConfig.php
+++ b/src/Config/EnvironmentConfig.php
@@ -2,6 +2,8 @@
 
 namespace Phoenix\Config;
 
+use PDO;
+
 class EnvironmentConfig
 {
     private $configuration;

--- a/src/Database/Adapter/AdapterFactory.php
+++ b/src/Database/Adapter/AdapterFactory.php
@@ -10,7 +10,7 @@ class AdapterFactory
 {
     public static function instance(EnvironmentConfig $config): AdapterInterface
     {
-        $pdo = $config->getConnection() ?: new PDO($config->getDsn(), $config->getUsername(), $config->getPassword());
+        $pdo = $config->getConnection();
 
         sscanf($config->getVersion() ?? $pdo->getAttribute(PDO::ATTR_SERVER_VERSION), '%d.%d.%d', $v1, $v2, $v3);
         $version = implode('.', array_filter([$v1, $v2, $v3], function ($v) {

--- a/src/Database/Adapter/AdapterFactory.php
+++ b/src/Database/Adapter/AdapterFactory.php
@@ -10,7 +10,7 @@ class AdapterFactory
 {
     public static function instance(EnvironmentConfig $config): AdapterInterface
     {
-        $pdo = new PDO($config->getDsn(), $config->getUsername(), $config->getPassword());
+        $pdo = $config->getConnection() ?: new PDO($config->getDsn(), $config->getUsername(), $config->getPassword());
 
         sscanf($config->getVersion() ?? $pdo->getAttribute(PDO::ATTR_SERVER_VERSION), '%d.%d.%d', $v1, $v2, $v3);
         $version = implode('.', array_filter([$v1, $v2, $v3], function ($v) {

--- a/src/Database/Adapter/AdapterInterface.php
+++ b/src/Database/Adapter/AdapterInterface.php
@@ -2,6 +2,7 @@
 
 namespace Phoenix\Database\Adapter;
 
+use PDO;
 use PDOStatement;
 use Phoenix\Database\Element\Structure;
 use Phoenix\Database\QueryBuilder\QueryBuilderInterface;
@@ -61,4 +62,11 @@ interface AdapterInterface
     public function getCharset(): ?string;
 
     public function getStructure(): Structure;
+
+    /**
+     * Gets current database connection
+     *
+     * @return PDO
+     */
+    public function getConnection(): PDO;
 }

--- a/src/Database/Adapter/PdoAdapter.php
+++ b/src/Database/Adapter/PdoAdapter.php
@@ -268,6 +268,14 @@ abstract class PdoAdapter implements AdapterInterface
         return $this->charset;
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function getConnection(): PDO
+    {
+        return $this->pdo;
+    }
+
     protected function getLengthAndDecimals(?string $lengthAndDecimals = null)
     {
         if ($lengthAndDecimals === null) {

--- a/src/Migration/AbstractMigration.php
+++ b/src/Migration/AbstractMigration.php
@@ -2,6 +2,7 @@
 
 namespace Phoenix\Migration;
 
+use PDO;
 use PDOStatement;
 use Phoenix\Database\Adapter\AdapterInterface;
 use Phoenix\Database\Element\MigrationTable;
@@ -87,6 +88,19 @@ abstract class AbstractMigration
     final protected function execute($sql): void
     {
         $this->queriesToExecute[] = $sql;
+    }
+
+    /**
+     * If for some reasons user needs to access to connection (for example he uses custom compatible database connection
+     * and he wants to access some functionality), this method can help.
+     *
+     * Warning: using this method directly can have some unknown consequences, so don't use it if there is another way
+     * to get required functionality.
+     *
+     * @return PDO
+     */
+    final protected function getConnection(): PDO {
+        return $this->adapter->getConnection();
     }
 
     /**

--- a/src/Migration/AbstractMigration.php
+++ b/src/Migration/AbstractMigration.php
@@ -99,7 +99,8 @@ abstract class AbstractMigration
      *
      * @return PDO
      */
-    final protected function getConnection(): PDO {
+    final protected function getConnection(): PDO
+    {
         return $this->adapter->getConnection();
     }
 

--- a/tests/Config/EnvironmentConfigTest.php
+++ b/tests/Config/EnvironmentConfigTest.php
@@ -128,6 +128,8 @@ class EnvironmentConfigTest extends TestCase
             'connection' => null,
         ]);
         $this->assertEquals('any_adapter', $environmentConfig->getAdapter());
-        $this->assertInstanceOf(PDO::class, $environmentConfig->getConnection());
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('db_name is not set for environment');
+        $environmentConfig->getConnection();
     }
 }

--- a/tests/Config/EnvironmentConfigTest.php
+++ b/tests/Config/EnvironmentConfigTest.php
@@ -2,8 +2,11 @@
 
 namespace Phoenix\Tests\Config;
 
+use PDO;
 use Phoenix\Config\EnvironmentConfig;
+use Phoenix\Exception\ConfigException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class EnvironmentConfigTest extends TestCase
 {
@@ -96,7 +99,7 @@ class EnvironmentConfigTest extends TestCase
 
     public function testCustomConnectionPDO()
     {
-        $pdo = new \PDO('sqlite::memory:');
+        $pdo = new PDO('sqlite::memory:');
         $environmentConfig = new EnvironmentConfig([
             'adapter' => 'any_adapter',
             'connection' => $pdo,
@@ -107,14 +110,15 @@ class EnvironmentConfigTest extends TestCase
 
     public function testCustomConnectionNotPDO()
     {
-        $connection = new \stdClass();
+        $connection = new stdClass();
         $environmentConfig = new EnvironmentConfig([
             'adapter' => 'any_adapter',
             'connection' => $connection,
         ]);
         $this->assertEquals('any_adapter', $environmentConfig->getAdapter());
-        $this->assertNotEquals($connection, $environmentConfig->getConnection());
-        $this->assertNull($environmentConfig->getConnection());
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Connection instance must extend PDO class');
+        $environmentConfig->getConnection();
     }
 
     public function testCustomConnectionNull()
@@ -124,6 +128,6 @@ class EnvironmentConfigTest extends TestCase
             'connection' => null,
         ]);
         $this->assertEquals('any_adapter', $environmentConfig->getAdapter());
-        $this->assertNull($environmentConfig->getConnection());
+        $this->assertInstanceOf(PDO::class, $environmentConfig->getConnection());
     }
 }

--- a/tests/Config/EnvironmentConfigTest.php
+++ b/tests/Config/EnvironmentConfigTest.php
@@ -119,13 +119,11 @@ class EnvironmentConfigTest extends TestCase
 
     public function testCustomConnectionNull()
     {
-        $connection = null;
         $environmentConfig = new EnvironmentConfig([
             'adapter' => 'any_adapter',
-            'connection' => $connection,
+            'connection' => null,
         ]);
         $this->assertEquals('any_adapter', $environmentConfig->getAdapter());
-        $this->assertNotEquals($connection, $environmentConfig->getConnection());
         $this->assertNull($environmentConfig->getConnection());
     }
 }

--- a/tests/Config/EnvironmentConfigTest.php
+++ b/tests/Config/EnvironmentConfigTest.php
@@ -93,4 +93,39 @@ class EnvironmentConfigTest extends TestCase
         $this->assertEquals('test_username', $environmentConfig->getUsername());
         $this->assertEquals('test_password', $environmentConfig->getPassword());
     }
+
+    public function testCustomConnectionPDO()
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $environmentConfig = new EnvironmentConfig([
+            'adapter' => 'any_adapter',
+            'connection' => $pdo,
+        ]);
+        $this->assertEquals('any_adapter', $environmentConfig->getAdapter());
+        $this->assertEquals($pdo, $environmentConfig->getConnection());
+    }
+
+    public function testCustomConnectionNotPDO()
+    {
+        $connection = new \stdClass();
+        $environmentConfig = new EnvironmentConfig([
+            'adapter' => 'any_adapter',
+            'connection' => $connection,
+        ]);
+        $this->assertEquals('any_adapter', $environmentConfig->getAdapter());
+        $this->assertNotEquals($connection, $environmentConfig->getConnection());
+        $this->assertNull($environmentConfig->getConnection());
+    }
+
+    public function testCustomConnectionNull()
+    {
+        $connection = null;
+        $environmentConfig = new EnvironmentConfig([
+            'adapter' => 'any_adapter',
+            'connection' => $connection,
+        ]);
+        $this->assertEquals('any_adapter', $environmentConfig->getAdapter());
+        $this->assertNotEquals($connection, $environmentConfig->getConnection());
+        $this->assertNull($environmentConfig->getConnection());
+    }
 }

--- a/tests/Database/Adapter/AdapterFactoryTest.php
+++ b/tests/Database/Adapter/AdapterFactoryTest.php
@@ -95,4 +95,45 @@ class AdapterFactoryTest extends TestCase
         $this->expectExceptionMessage('Unknown adapter "unknown". Use one of value: "mysql", "pgsql".');
         AdapterFactory::instance($config);
     }
+
+    public function testCustomConnectionMySQL()
+    {
+        $connection = new \PDO('sqlite::memory:');
+
+        $config = new EnvironmentConfig([
+            'adapter' => 'mysql',
+            'connection' => $connection,
+        ]);
+
+        $adapter = AdapterFactory::instance($config);
+        $this->assertInstanceOf(MysqlAdapter::class, $adapter);
+        $this->assertEquals($connection, $adapter->getConnection());
+    }
+
+    public function testCustomConnectionPgsql()
+    {
+        $connection = new \PDO('sqlite::memory:');
+
+        $config = new EnvironmentConfig([
+            'adapter' => 'pgsql',
+            'connection' => $connection,
+        ]);
+
+        $adapter = AdapterFactory::instance($config);
+        $this->assertInstanceOf(PgsqlAdapter::class, $adapter);
+        $this->assertEquals($connection, $adapter->getConnection());
+    }
+
+    public function testBadCustomConnectionWithGoodDSNString()
+    {
+        $config = new EnvironmentConfig([
+            'adapter' => 'pgsql',
+            'connection' => 'random string',
+            'dsn' => 'sqlite::memory:'
+        ]);
+
+        $adapter = AdapterFactory::instance($config);
+        $this->assertInstanceOf(PgsqlAdapter::class, $adapter);
+        $this->assertNotEquals('random string', $adapter->getConnection());
+    }
 }

--- a/tests/Database/Adapter/AdapterFactoryTest.php
+++ b/tests/Database/Adapter/AdapterFactoryTest.php
@@ -9,6 +9,7 @@ use Phoenix\Database\Adapter\MysqlAdapter;
 use Phoenix\Database\Adapter\PgsqlAdapter;
 use Phoenix\Database\QueryBuilder\MysqlQueryBuilder;
 use Phoenix\Database\QueryBuilder\MysqlWithJsonQueryBuilder;
+use Phoenix\Exception\ConfigException;
 use Phoenix\Exception\InvalidArgumentValueException;
 use PHPUnit\Framework\TestCase;
 
@@ -133,8 +134,32 @@ class AdapterFactoryTest extends TestCase
             'dsn' => 'sqlite::memory:'
         ]);
 
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Connection instance must extend PDO class');
+        AdapterFactory::instance($config);
+    }
+
+    public function testBadCustomConnectionWithoutGoodDSNString()
+    {
+        $config = new EnvironmentConfig([
+            'adapter' => 'pgsql',
+            'connection' => 'random string'
+        ]);
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Connection instance must extend PDO class');
+        AdapterFactory::instance($config);
+    }
+
+    public function testNullCustomConnectionWithGoodDSNString()
+    {
+        $config = new EnvironmentConfig([
+            'adapter' => 'pgsql',
+            'connection' => null,
+            'dsn' => 'sqlite::memory:'
+        ]);
+
         $adapter = AdapterFactory::instance($config);
         $this->assertInstanceOf(PgsqlAdapter::class, $adapter);
-        $this->assertNotEquals('random string', $adapter->getConnection());
     }
 }

--- a/tests/Database/Adapter/AdapterFactoryTest.php
+++ b/tests/Database/Adapter/AdapterFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Phoenix\Tests\Database\Adapter;
 
+use PDO;
 use Phoenix\Config\EnvironmentConfig;
 use Phoenix\Database\Adapter\AdapterFactory;
 use Phoenix\Database\Adapter\MysqlAdapter;
@@ -98,7 +99,7 @@ class AdapterFactoryTest extends TestCase
 
     public function testCustomConnectionMySQL()
     {
-        $connection = new \PDO('sqlite::memory:');
+        $connection = new PDO('sqlite::memory:');
 
         $config = new EnvironmentConfig([
             'adapter' => 'mysql',
@@ -112,7 +113,7 @@ class AdapterFactoryTest extends TestCase
 
     public function testCustomConnectionPgsql()
     {
-        $connection = new \PDO('sqlite::memory:');
+        $connection = new PDO('sqlite::memory:');
 
         $config = new EnvironmentConfig([
             'adapter' => 'pgsql',


### PR DESCRIPTION
This pull request implements idea from #206 comments. From now is possible with PHP based configuration reuse existing database connection with 'connection' parameter and get access to it from migration.

For example, such configuration now is possible:
```php
<?php

$connection = new \PDO();

return [
    'migration_dirs' => [
        'phoenix' => __DIR__ . '/../testing_migrations/phoenix',
    ],
    'environments' => [
        'mysql' => [
            'adapter' => 'mysql',
            'connection' => $connection,
        ]
    ],
];
```
If `connection` is not type of PDO instance other configuration options will be used. So, all old configurations should work fine.

And this is example how is possible to access database connection from migration:
```php
<?php

namespace Phoenix\DemoMigrations;

use Phoenix\Migration\AbstractMigration;

class DoSomethingFancyWithDatabaseConnection extends AbstractMigration
{
    public function up(): void
    {
        $connection = $this->getConnection();
        // and here we can do something with this database connection (f.e. prefixing tables as needed)
    }

    public function down(): void
    {
        $connection = $this->getConnection();
        // and here we can do something with this database connection (f.e. prefixing tables as needed)
    }
}
```