### PR TITLE
Fixes escapeString in QueryBuilderInterface signature

### DIFF
--- a/src/Database/QueryBuilder/QueryBuilderInterface.php
+++ b/src/Database/QueryBuilder/QueryBuilderInterface.php
@@ -43,8 +43,8 @@ interface QueryBuilderInterface
     public function truncateTable(MigrationTable $table): array;
 
     /**
-     * @param string $string
+     * @param string|null $string
      * @return string escaped string
      */
-    public function escapeString(string $string): string;
+    public function escapeString(?string $string): string;
 }


### PR DESCRIPTION
This should fix all these errors that I got on Travis when I have submited #208 pull request (with PHP 7.1):
```
 ------ ----------------------------------------------------------------------- 
  Line   Database/QueryBuilder/CommonQueryBuilder.php                           
 ------ ----------------------------------------------------------------------- 
  244    Parameter #1 $string (string|null) of method                           
         Phoenix\Database\QueryBuilder\CommonQueryBuilder::escapeString() does  
         not match parameter #1 $string (string) of method                      
         Phoenix\Database\QueryBuilder\QueryBuilderInterface::escapeString().   
 ------ ----------------------------------------------------------------------- 
 ------ ---------------------------------------------------------------------- 
  Line   Database/QueryBuilder/MysqlQueryBuilder.php                           
 ------ ---------------------------------------------------------------------- 
  262    Parameter #1 $string (string|null) of method                          
         Phoenix\Database\QueryBuilder\MysqlQueryBuilder::escapeString() does  
         not match parameter #1 $string (string) of method                     
         Phoenix\Database\QueryBuilder\QueryBuilderInterface::escapeString().  
 ------ ---------------------------------------------------------------------- 
 ------ ---------------------------------------------------------------------- 
  Line   Database/QueryBuilder/PgsqlQueryBuilder.php                           
 ------ ---------------------------------------------------------------------- 
  259    Parameter #1 $string (string|null) of method                          
         Phoenix\Database\QueryBuilder\PgsqlQueryBuilder::escapeString() does  
         not match parameter #1 $string (string) of method                     
         Phoenix\Database\QueryBuilder\QueryBuilderInterface::escapeString().  
 ------ ---------------------------------------------------------------------- 
```