### PR TITLE
Fixed bug unescaped column value. 'b'0'' -> 'b\'0\''

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 #### Fixed
 - PHP 8.1 deprecation notice
 
+### [1.5.1] - 2021-03-23
+#### Fixed
+- escaping column value in Dumper
+
 ### [1.5.0] - 2021-01-25
 #### Changed
 - moved tests from travis to github actions and removed scrutinizer

--- a/src/Dumper/Dumper.php
+++ b/src/Dumper/Dumper.php
@@ -170,7 +170,7 @@ class Dumper
     private function valuesToString(array $values): string
     {
         $values = array_map(function ($value) {
-            return "'$value'";
+            return "'" . addslashes($value) . "'";
         }, $values);
         return '[' . implode(', ', $values) . ']';
     }
@@ -265,7 +265,7 @@ class Dumper
         } elseif (is_array($value)) {
             $value = $this->valuesToString($value);
         } elseif (!is_numeric($value)) {
-            $value = "'$value'";
+            $value = "'" . addslashes($value) . "'";
         }
         return $value;
     }

--- a/src/Dumper/Dumper.php
+++ b/src/Dumper/Dumper.php
@@ -170,7 +170,7 @@ class Dumper
     private function valuesToString(array $values): string
     {
         $values = array_map(function ($value) {
-            return "'" . addslashes($value) . "'";
+            return "'" . str_replace("'", "\'", $value) . "'";
         }, $values);
         return '[' . implode(', ', $values) . ']';
     }
@@ -265,7 +265,7 @@ class Dumper
         } elseif (is_array($value)) {
             $value = $this->valuesToString($value);
         } elseif (!is_numeric($value)) {
-            $value = "'" . addslashes($value) . "'";
+            $value = "'" . str_replace("'", "\'", $value) . "'";
         }
         return $value;
     }


### PR DESCRIPTION
While doing the dump, I noticed a syntax error in the resulting file. In the value of a field of type bit, quotes in the value were not escaped. This fixes this bug.