### PR TITLE
Add operator to column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [Unreleased][unreleased]
 
+### [1.8.1] - 2021-06-01
+#### Changed
+- add support for different operators in `$conditions` array
+
 ### [1.8.0] - 2021-06-01
 #### Added
 - year column type (year for mysql, numeric(4) for pgsql)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### [Unreleased][unreleased]
 
-### [1.8.1] - 2021-06-01
 #### Changed
 - add support for different operators in `$conditions` array
 

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -85,3 +85,39 @@ $this->execute('CREATE TABLE `first_table` (
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;'
 );
 ```
+
+### Fetch data
+`$this->fetch` and `$this->fetchAll` accept the following arguments:
+name|description|type|optional|default
+-|-|-|-|-
+table|The name of the table from which fetch the data|string|no|-
+fields|A list of column names to return|array|yes|`['*']`
+conditions|A list of condition, where the key of the associative array will be the column name and the value will be the compared value.<br><br>By default the operator of the comparison is '=' but you can specify the operator in the array key just after the column name preceded by a space (e.g. `column !=` or `column >`)|array|yes|`[]`
+groups|A list of column names to group by|array|yes|`[]`
+
+#### Fetch with conditions
+```php
+$trackableOrders = $this->fetchAll(
+    'orders',
+    [
+        'id'
+    ],
+    [
+        'user_id' => 12,
+        'tracking_id !=' => null
+    ]
+);
+```
+
+```php
+$orders = $this->fetchAll(
+    'orders',
+    [
+        'id'
+    ],
+    [
+        'user_id =' => 12,
+        'price >=' => 23.50
+    ]
+);
+```

--- a/src/Database/Adapter/PdoAdapter.php
+++ b/src/Database/Adapter/PdoAdapter.php
@@ -408,7 +408,7 @@ abstract class PdoAdapter implements AdapterInterface
         return true;
     }
 
-    private function splitColumnNameAndOperator(string $key, $value, string &$columnName, string &$operator): void
+    private function splitColumnNameAndOperator(string $key, mixed $value, ?string &$columnName, ?string &$operator): void
     {
         // initialize both column name and operator
         $columnName = $key;

--- a/src/Database/Adapter/PdoAdapter.php
+++ b/src/Database/Adapter/PdoAdapter.php
@@ -411,7 +411,7 @@ abstract class PdoAdapter implements AdapterInterface
     /**
      * @param string $key
      * @param mixed $value
-     * @return array [ columnName, operator ]
+     * @return array<string, string> [ columnName, operator ]
      */
     private function splitColumnNameAndOperator(string $key, $value): array
     {

--- a/src/Database/Adapter/PdoAdapter.php
+++ b/src/Database/Adapter/PdoAdapter.php
@@ -238,7 +238,6 @@ abstract class PdoAdapter implements AdapterInterface
      */
     private function addCondition(string $key, $value): string
     {
-        $rightOperand = null;
         $this->splitColumnNameAndOperator($key, $value, $columnName, $operator);
         if (is_array($value)) {
             $inConditions = [];
@@ -409,14 +408,14 @@ abstract class PdoAdapter implements AdapterInterface
         return true;
     }
 
-    private function splitColumnNameAndOperator($key, $value, &$columnName, &$operator): void
+    private function splitColumnNameAndOperator(string $key, $value, string &$columnName, string &$operator): void
     {
         // initialize both column name and operator
         $columnName = $key;
         $operator = '=';
 
         // check presence of operator in $key
-        if (preg_match('/^(.*)\s(=|!=|<>|<|<=|>|>=)$/', $key, $matches) === 1) {
+        if (preg_match('/^(.*) (=|!=|<>|<|<=|>|>=)$/', $key, $matches) === 1) {
             $columnName = $matches[1];
             $operator = $matches[2];
         }

--- a/tests/Database/Adapter/PdoAdapterTest.php
+++ b/tests/Database/Adapter/PdoAdapterTest.php
@@ -127,22 +127,13 @@ class PdoAdapterTest extends TestCase
         $this->assertEquals(1, $this->adapter->insert('phoenix_test_table', ['id' => 1, 'title' => 'first']));
         $this->assertEquals(2, $this->adapter->insert('phoenix_test_table', ['id' => 2, 'title' => NULL]));
 
-        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title' => 'NOT NULL']);
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title !=' => NULL]);
         $this->assertCount(1, $items);
         foreach ($items as $item) {
             $this->assertCount(2, $item);
             $this->assertArrayHasKey('id', $item);
             $this->assertArrayHasKey('title', $item);
             $this->assertNotNull($item['title']);
-        }
-
-        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title' => 'NULL']);
-        $this->assertCount(1, $items);
-        foreach ($items as $item) {
-            $this->assertCount(2, $item);
-            $this->assertArrayHasKey('id', $item);
-            $this->assertArrayHasKey('title', $item);
-            $this->assertNull($item['title']);
         }
 
         $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title' => NULL]);

--- a/tests/Database/Adapter/PdoAdapterTest.php
+++ b/tests/Database/Adapter/PdoAdapterTest.php
@@ -122,7 +122,7 @@ class PdoAdapterTest extends TestCase
         }
     }
 
-    public function testFetchAllWhereNull()
+    public function testFetchAllWithConditions()
     {
         $this->adapter->query('CREATE TABLE `phoenix_test_table` (`id` int NOT NULL AUTO_INCREMENT,`title` varchar(255) NULL,PRIMARY KEY (`id`));');
         $this->assertEquals(1, $this->adapter->insert('phoenix_test_table', ['id' => 1, 'title' => 'first']));
@@ -144,6 +144,42 @@ class PdoAdapterTest extends TestCase
             $this->assertArrayHasKey('id', $item);
             $this->assertArrayHasKey('title', $item);
             $this->assertNull($item['title']);
+        }
+
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['id >' => 1]);
+        $this->assertCount(1, $items);
+        foreach ($items as $item) {
+            $this->assertCount(2, $item);
+            $this->assertArrayHasKey('id', $item);
+            $this->assertArrayHasKey('title', $item);
+            $this->assertGreaterThan($item['id'], 1);
+        }
+        
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['id >=' => 1]);
+        $this->assertCount(2, $items);
+        foreach ($items as $item) {
+            $this->assertCount(2, $item);
+            $this->assertArrayHasKey('id', $item);
+            $this->assertArrayHasKey('title', $item);
+            $this->assertGreaterThanOrEqual($item['id'], 1);
+        }
+        
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['id <' => 2]);
+        $this->assertCount(1, $items);
+        foreach ($items as $item) {
+            $this->assertCount(2, $item);
+            $this->assertArrayHasKey('id', $item);
+            $this->assertArrayHasKey('title', $item);
+            $this->assertLessThan($item['id'], 2);
+        }
+        
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['id <=' => 2]);
+        $this->assertCount(2, $items);
+        foreach ($items as $item) {
+            $this->assertCount(2, $item);
+            $this->assertArrayHasKey('id', $item);
+            $this->assertArrayHasKey('title', $item);
+            $this->assertLessThanOrEqual($item['id'], 2);
         }
         
         $this->expectException(UnexpectedValueException::class);

--- a/tests/Database/Adapter/PdoAdapterTest.php
+++ b/tests/Database/Adapter/PdoAdapterTest.php
@@ -121,6 +121,40 @@ class PdoAdapterTest extends TestCase
         }
     }
 
+    public function testFetchAllWhereNull()
+    {
+        $this->adapter->query('CREATE TABLE `phoenix_test_table` (`id` int NOT NULL AUTO_INCREMENT,`title` varchar(255) NULL,PRIMARY KEY (`id`));');
+        $this->assertEquals(1, $this->adapter->insert('phoenix_test_table', ['id' => 1, 'title' => 'first']));
+        $this->assertEquals(2, $this->adapter->insert('phoenix_test_table', ['id' => 2, 'title' => NULL]));
+
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title' => 'NOT NULL']);
+        $this->assertCount(1, $items);
+        foreach ($items as $item) {
+            $this->assertCount(2, $item);
+            $this->assertArrayHasKey('id', $item);
+            $this->assertArrayHasKey('title', $item);
+            $this->assertNotNull($item['title']);
+        }
+
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title' => 'NULL']);
+        $this->assertCount(1, $items);
+        foreach ($items as $item) {
+            $this->assertCount(2, $item);
+            $this->assertArrayHasKey('id', $item);
+            $this->assertArrayHasKey('title', $item);
+            $this->assertNull($item['title']);
+        }
+
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title' => NULL]);
+        $this->assertCount(1, $items);
+        foreach ($items as $item) {
+            $this->assertCount(2, $item);
+            $this->assertArrayHasKey('id', $item);
+            $this->assertArrayHasKey('title', $item);
+            $this->assertNull($item['title']);
+        }
+    }
+
     public function testDelete()
     {
         $this->adapter->query('CREATE TABLE `phoenix_test_table` (`id` int NOT NULL AUTO_INCREMENT,`title` varchar(255) NOT NULL,PRIMARY KEY (`id`));');

--- a/tests/Database/Adapter/PdoAdapterTest.php
+++ b/tests/Database/Adapter/PdoAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Phoenix\Tests\Database\Adapter;
 
 use InvalidArgumentException;
+use UnexpectedValueException;
 use Phoenix\Database\QueryBuilder\QueryBuilderInterface;
 use Phoenix\Exception\DatabaseQueryExecuteException;
 use Phoenix\Tests\Helpers\Adapter\MysqlCleanupAdapter;
@@ -144,6 +145,10 @@ class PdoAdapterTest extends TestCase
             $this->assertArrayHasKey('title', $item);
             $this->assertNull($item['title']);
         }
+        
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Cannot accept "<" operator for NULL value');
+        $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['title <' => NULL]);
     }
 
     public function testDelete()

--- a/tests/Database/Adapter/PdoAdapterTest.php
+++ b/tests/Database/Adapter/PdoAdapterTest.php
@@ -152,7 +152,7 @@ class PdoAdapterTest extends TestCase
             $this->assertCount(2, $item);
             $this->assertArrayHasKey('id', $item);
             $this->assertArrayHasKey('title', $item);
-            $this->assertGreaterThan($item['id'], 1);
+            $this->assertGreaterThan(1, $item['id']);
         }
         
         $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['id >=' => 1]);
@@ -161,7 +161,7 @@ class PdoAdapterTest extends TestCase
             $this->assertCount(2, $item);
             $this->assertArrayHasKey('id', $item);
             $this->assertArrayHasKey('title', $item);
-            $this->assertGreaterThanOrEqual($item['id'], 1);
+            $this->assertGreaterThanOrEqual(1, $item['id']);
         }
         
         $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['id <' => 2]);
@@ -170,7 +170,7 @@ class PdoAdapterTest extends TestCase
             $this->assertCount(2, $item);
             $this->assertArrayHasKey('id', $item);
             $this->assertArrayHasKey('title', $item);
-            $this->assertLessThan($item['id'], 2);
+            $this->assertLessThan(2, $item['id']);
         }
         
         $items = $this->adapter->fetchAll('phoenix_test_table', ['*'], ['id <=' => 2]);
@@ -179,7 +179,7 @@ class PdoAdapterTest extends TestCase
             $this->assertCount(2, $item);
             $this->assertArrayHasKey('id', $item);
             $this->assertArrayHasKey('title', $item);
-            $this->assertLessThanOrEqual($item['id'], 2);
+            $this->assertLessThanOrEqual(2, $item['id']);
         }
         
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
Here you can specify the operator in the keys of $conditions array right after the column name, separated by a space character.

It will be converted to the correct operator based on the condition value.

If value is `NULL`:
- `'column ='` => `` `column` IS NULL ``
- `'column !='` => `` `column` IS NOT NULL ``
- `'column <>'` => `` `column` IS NOT NULL ``
- any other operator will throw an `UnexpectedValueException`

If value is an array:
- `'column ='` => `` `column` IN (...) ``
- `'column !='` => `` `column` NOT IN (...) ``
- `'column <>'` => `` `column` NOT IN (...) ``
- any other operator will throw an `UnexpectedValueException`

If anything else it will be kept as is, except for `!=` that will always be converted to `<>`.

The column name will always be trimmed, so it won't ever have trailing or leading spaces.

**Any space character is mandatory between column name and operator**