### PR TITLE
Forced version of mysql 8 in tests

### DIFF
--- a/.github/workflows/phpunit_lowest_mysql8_psql14.yml
+++ b/.github/workflows/phpunit_lowest_mysql8_psql14.yml
@@ -18,7 +18,7 @@ jobs:
 
     services:
       mysql:
-        image: bitnami/mysql:8.0
+        image: bitnami/mysql:8.0.27
         env:
           MYSQL_DATABASE: phoenix
           MYSQL_ROOT_PASSWORD: 123

--- a/.github/workflows/phpunit_mysql8_psql14.yml
+++ b/.github/workflows/phpunit_mysql8_psql14.yml
@@ -18,7 +18,7 @@ jobs:
 
     services:
       mysql:
-        image: bitnami/mysql:8.0
+        image: bitnami/mysql:8.0.27
         env:
           MYSQL_DATABASE: phoenix
           MYSQL_ROOT_PASSWORD: 123


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html

"Historically, MySQL has used utf8 as an alias for utf8mb3; beginning with MySQL 8.0.28, utf8mb3 is used exclusively in the output of SHOW statements and in Information Schema tables when this character set is meant."