### PR TITLE
add integer value column for escapeDefault

### DIFF
--- a/src/Database/QueryBuilder/MysqlQueryBuilder.php
+++ b/src/Database/QueryBuilder/MysqlQueryBuilder.php
@@ -237,7 +237,7 @@ final class MysqlQueryBuilder extends CommonQueryBuilder implements QueryBuilder
 
         if ($column->getSettings()->getDefault() !== null || $column->getType() === Column::TYPE_BOOLEAN) {
             $default = ' DEFAULT ';
-            if (in_array($column->getType(), [Column::TYPE_INTEGER, Column::TYPE_BIT], true)) {
+            if (in_array($column->getType(), [Column::TYPE_TINY_INTEGER, Column::TYPE_SMALL_INTEGER, Column::TYPE_MEDIUM_INTEGER, Column::TYPE_INTEGER, Column::TYPE_BIG_INTEGER, Column::TYPE_BIT], true)) {
                 return $default . $column->getSettings()->getDefault();
             }
             if (in_array($column->getType(), [Column::TYPE_BOOLEAN], true)) {

--- a/src/Database/QueryBuilder/PgsqlQueryBuilder.php
+++ b/src/Database/QueryBuilder/PgsqlQueryBuilder.php
@@ -231,7 +231,7 @@ final class PgsqlQueryBuilder extends CommonQueryBuilder implements QueryBuilder
 
     private function escapeDefault(Column $column): string
     {
-        if (in_array($column->getType(), [Column::TYPE_INTEGER, Column::TYPE_BIT], true)) {
+        if (in_array($column->getType(), [Column::TYPE_TINY_INTEGER, Column::TYPE_SMALL_INTEGER, Column::TYPE_MEDIUM_INTEGER, Column::TYPE_INTEGER, Column::TYPE_BIG_INTEGER, Column::TYPE_BIT], true)) {
             $default = (string)$column->getSettings()->getDefault();
         } elseif (in_array($column->getType(), [Column::TYPE_BOOLEAN], true)) {
             $default = $column->getSettings()->getDefault() ? 'true' : 'false';

--- a/tests/Database/QueryBuilder/MysqlQueryBuilderTest.php
+++ b/tests/Database/QueryBuilder/MysqlQueryBuilderTest.php
@@ -65,12 +65,12 @@ final class MysqlQueryBuilderTest extends TestCase
         $table = new MigrationTable('all_types');
         $table->addPrimary(true);
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_uuid', 'uuid'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bit', 'bit'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_tinyint', 'tinyinteger'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_smallint', 'smallinteger'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_mediumint', 'mediuminteger'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_int', 'integer', ['signed' => false]));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bigint', 'biginteger'));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bit', 'bit', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_tinyint', 'tinyinteger', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_smallint', 'smallinteger', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_mediumint', 'mediuminteger', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_int', 'integer', ['signed' => false, 'default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bigint', 'biginteger', ['default' => 0]));
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_string', 'string'));
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_char', 'char'));
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_binary', 'binary'));
@@ -103,7 +103,7 @@ final class MysqlQueryBuilderTest extends TestCase
 
         $queryBuilder = new MysqlQueryBuilder($this->adapter);
         $expectedQueries = [
-            "CREATE TABLE `all_types` (`id` int(11) NOT NULL AUTO_INCREMENT,`col_uuid` char(36) NOT NULL,`col_bit` bit(32) NOT NULL,`col_tinyint` tinyint(4) NOT NULL,`col_smallint` smallint(6) NOT NULL,`col_mediumint` mediumint(9) NOT NULL,`col_int` int(11) unsigned NOT NULL,`col_bigint` bigint(20) NOT NULL,`col_string` varchar(255) NOT NULL,`col_char` char(255) NOT NULL,`col_binary` binary(255) NOT NULL,`col_varbinary` varbinary(255) NOT NULL,`col_tinytext` tinytext NOT NULL,`col_mediumtext` mediumtext NOT NULL,`col_text` text NOT NULL,`col_longtext` longtext NOT NULL,`col_tinyblob` tinyblob NOT NULL,`col_mediumblob` mediumblob NOT NULL,`col_blob` blob NOT NULL,`col_longblob` longblob NOT NULL,`col_json` text NOT NULL,`col_numeric` decimal(10,3) NOT NULL,`col_decimal` decimal(10,3) NOT NULL,`col_float` float(10,3) NOT NULL,`col_double` double(10,3) NOT NULL,`col_boolean` tinyint(1) NOT NULL DEFAULT 0,`col_datetime` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,`col_date` date NOT NULL,`col_enum` enum('xxx','yyy','zzz') NOT NULL,`col_set` set('xxx','yyy','zzz') NOT NULL,`col_point` point DEFAULT NULL,`col_line` linestring DEFAULT NULL,`col_polygon` polygon DEFAULT NULL,`col_time` time DEFAULT NULL,`col_timestamp` timestamp NULL DEFAULT CURRENT_TIMESTAMP,`col_null_timestamp` timestamp NULL DEFAULT NULL,`col_year` year NOT NULL,PRIMARY KEY (`id`));"
+            "CREATE TABLE `all_types` (`id` int(11) NOT NULL AUTO_INCREMENT,`col_uuid` char(36) NOT NULL,`col_bit` bit(32) NOT NULL DEFAULT 0,`col_tinyint` tinyint(4) NOT NULL DEFAULT 0,`col_smallint` smallint(6) NOT NULL DEFAULT 0,`col_mediumint` mediumint(9) NOT NULL DEFAULT 0,`col_int` int(11) unsigned NOT NULL DEFAULT 0,`col_bigint` bigint(20) NOT NULL DEFAULT 0,`col_string` varchar(255) NOT NULL,`col_char` char(255) NOT NULL,`col_binary` binary(255) NOT NULL,`col_varbinary` varbinary(255) NOT NULL,`col_tinytext` tinytext NOT NULL,`col_mediumtext` mediumtext NOT NULL,`col_text` text NOT NULL,`col_longtext` longtext NOT NULL,`col_tinyblob` tinyblob NOT NULL,`col_mediumblob` mediumblob NOT NULL,`col_blob` blob NOT NULL,`col_longblob` longblob NOT NULL,`col_json` text NOT NULL,`col_numeric` decimal(10,3) NOT NULL,`col_decimal` decimal(10,3) NOT NULL,`col_float` float(10,3) NOT NULL,`col_double` double(10,3) NOT NULL,`col_boolean` tinyint(1) NOT NULL DEFAULT 0,`col_datetime` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,`col_date` date NOT NULL,`col_enum` enum('xxx','yyy','zzz') NOT NULL,`col_set` set('xxx','yyy','zzz') NOT NULL,`col_point` point DEFAULT NULL,`col_line` linestring DEFAULT NULL,`col_polygon` polygon DEFAULT NULL,`col_time` time DEFAULT NULL,`col_timestamp` timestamp NULL DEFAULT CURRENT_TIMESTAMP,`col_null_timestamp` timestamp NULL DEFAULT NULL,`col_year` year NOT NULL,PRIMARY KEY (`id`));"
         ];
         $this->assertEquals($expectedQueries, $queryBuilder->createTable($table));
     }

--- a/tests/Database/QueryBuilder/PgsqlQueryBuilderTest.php
+++ b/tests/Database/QueryBuilder/PgsqlQueryBuilderTest.php
@@ -62,12 +62,12 @@ final class PgsqlQueryBuilderTest extends TestCase
         $table->addPrimary('id');
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('id', 'biginteger', ['autoincrement' => true]));
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_uuid', 'uuid'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bit', 'bit'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_tinyint', 'tinyinteger'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_smallint', 'smallinteger'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_mediumint', 'mediuminteger'));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_int', 'integer', ['signed' => false]));
-        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bigint', 'biginteger'));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bit', 'bit', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_tinyint', 'tinyinteger', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_smallint', 'smallinteger', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_mediumint', 'mediuminteger', ['default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_int', 'integer', ['signed' => false, 'default' => 0]));
+        $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_bigint', 'biginteger', ['default' => 0]));
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_string', 'string'));
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_char', 'char'));
         $this->assertInstanceOf(MigrationTable::class, $table->addColumn('col_binary', 'binary'));
@@ -102,7 +102,7 @@ final class PgsqlQueryBuilderTest extends TestCase
         $expectedQueries = [
             'CREATE TYPE "all_types__col_enum" AS ENUM (\'xxx\',\'yyy\',\'zzz\');',
             'CREATE TYPE "all_types__col_set" AS ENUM (\'xxx\',\'yyy\',\'zzz\');',
-            'CREATE TABLE "all_types" ("id" bigserial NOT NULL,"col_uuid" uuid NOT NULL,"col_bit" bit(32) NOT NULL,"col_tinyint" int2 NOT NULL,"col_smallint" int2 NOT NULL,"col_mediumint" int4 NOT NULL,"col_int" int4 NOT NULL,"col_bigint" int8 NOT NULL,"col_string" varchar(255) NOT NULL,"col_char" char(255) NOT NULL,"col_binary" bytea NOT NULL,"col_varbinary" bytea NOT NULL,"col_tinytext" text NOT NULL,"col_mediumtext" text NOT NULL,"col_text" text NOT NULL,"col_longtext" text NOT NULL,"col_tinyblob" bytea NOT NULL,"col_mediumblob" bytea NOT NULL,"col_blob" bytea NOT NULL,"col_longblob" bytea NOT NULL,"col_json" json NOT NULL,"col_numeric" numeric(10,3) NOT NULL,"col_decimal" numeric(10,3) NOT NULL,"col_float" float4 NOT NULL,"col_double" float8 NOT NULL,"col_boolean" bool DEFAULT false NOT NULL,"col_datetime" timestamp(6) NOT NULL,"col_date" date NOT NULL,"col_enum" all_types__col_enum NOT NULL,"col_set" all_types__col_set[] NOT NULL,"col_point" point DEFAULT NULL,"col_line" line DEFAULT NULL,"col_polygon" polygon DEFAULT NULL,"col_time" time DEFAULT NULL,"col_timestamp" timestamp(6) DEFAULT CURRENT_TIMESTAMP,"col_timestamp_tz" timestamptz DEFAULT NULL,"col_year" numeric(4) NOT NULL,CONSTRAINT "all_types_pkey" PRIMARY KEY ("id"));'
+            'CREATE TABLE "all_types" ("id" bigserial NOT NULL,"col_uuid" uuid NOT NULL,"col_bit" bit(32) DEFAULT 0 NOT NULL,"col_tinyint" int2 DEFAULT 0 NOT NULL,"col_smallint" int2 DEFAULT 0 NOT NULL,"col_mediumint" int4 DEFAULT 0 NOT NULL,"col_int" int4 DEFAULT 0 NOT NULL,"col_bigint" int8 DEFAULT 0 NOT NULL,"col_string" varchar(255) NOT NULL,"col_char" char(255) NOT NULL,"col_binary" bytea NOT NULL,"col_varbinary" bytea NOT NULL,"col_tinytext" text NOT NULL,"col_mediumtext" text NOT NULL,"col_text" text NOT NULL,"col_longtext" text NOT NULL,"col_tinyblob" bytea NOT NULL,"col_mediumblob" bytea NOT NULL,"col_blob" bytea NOT NULL,"col_longblob" bytea NOT NULL,"col_json" json NOT NULL,"col_numeric" numeric(10,3) NOT NULL,"col_decimal" numeric(10,3) NOT NULL,"col_float" float4 NOT NULL,"col_double" float8 NOT NULL,"col_boolean" bool DEFAULT false NOT NULL,"col_datetime" timestamp(6) NOT NULL,"col_date" date NOT NULL,"col_enum" all_types__col_enum NOT NULL,"col_set" all_types__col_set[] NOT NULL,"col_point" point DEFAULT NULL,"col_line" line DEFAULT NULL,"col_polygon" polygon DEFAULT NULL,"col_time" time DEFAULT NULL,"col_timestamp" timestamp(6) DEFAULT CURRENT_TIMESTAMP,"col_timestamp_tz" timestamptz DEFAULT NULL,"col_year" numeric(4) NOT NULL,CONSTRAINT "all_types_pkey" PRIMARY KEY ("id"));'
         ];
         $this->assertEquals($expectedQueries, $queryBuilder->createTable($table));
     }


### PR DESCRIPTION
version: 2.4.0
database: postgresql

```php
$this->table('example')
    ->addColumn('count', 'biginteger', ['default' => 0])
    ->create();
```

```
Fatal error: Uncaught TypeError: Phoenix\Database\QueryBuilder\PgsqlQueryBuilder::sanitizeSingleQuote(): Argument #1 ($input) must be of type string, int given, called in /var/app/vendor/lulco/phoenix/src/Database/QueryBuilder/PgsqlQueryBuilder.php on line 241 and defined in /var/app/vendor/lulco/phoenix/src/Database/QueryBuilder/PgsqlQueryBuilder.php:351
```
