### PR TITLE
Configurable adapter factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^8.4",
         "ext-json": "*",
         "ext-pdo": "*",
-        "symfony/console": "^8.0",
+        "symfony/console": "^7.4 || ^8.0",
         "symfony/finder": "^7.0"
     },
     "require-dev": {

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -11,6 +11,7 @@ Configuration array can consist of five parts:
 - `dependencies` - array - list of dependencies which can be used in __construct of Migration classes. Key is type of dependency (class or interface name which will be used in __construct) and value is object of this type
 - `template` - string - path to template file for migrations (used in create, dump and diff commands)
 - `indent` - string - indentation in created migrations. Available values: 2spaces, 3spaces, 4spaces, 5spaces, tab [default: 4spaces]
+- `adapter_factory_class` - string - fully qualified class name of a custom adapter factory. The class must implement `Phoenix\Database\Adapter\AdapterFactoryInterface`. This allows adding custom database adapters. [default: `Phoenix\Database\Adapter\AdapterFactory`]
 
 ### Example
 Let's say you want to create configuration file, where `log_table_name` is "my_phoenix_log", you have two `migration_dirs` (first and second, which are located in the same directory as configuration file), also two `environments` both uses mysql adapter, and your `default_environment` is "local". Now we show you, how this config looks like using different type of configuration files:

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -7,7 +7,6 @@ namespace Phoenix\Command;
 use InvalidArgumentException;
 use Phoenix\Config\Config;
 use Phoenix\Config\Parser\ConfigParserFactory;
-use Phoenix\Database\Adapter\AdapterFactory;
 use Phoenix\Database\Adapter\AdapterInterface;
 use Phoenix\Exception\ConfigException;
 use Phoenix\Exception\DatabaseQueryExecuteException;
@@ -69,7 +68,8 @@ abstract class AbstractCommand extends Command
         if (!$environmentConfig) {
             throw new InvalidArgumentException('Environment ' . $environment . ' doesn\'t exist');
         }
-        $this->adapter = AdapterFactory::instance($environmentConfig);
+        $adapterFactoryClass = $this->getConfig()->getAdapterFactoryClass();
+        $this->adapter = $adapterFactoryClass::instance($environmentConfig);
 
         $this->manager = new Manager($this->getConfig(), $this->adapter);
         $this->check();

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phoenix\Command;
 
-use Phoenix\Database\Adapter\AdapterFactory;
 use Phoenix\Database\Element\Structure;
 use Phoenix\Dumper\Dumper;
 use Phoenix\Exception\InvalidArgumentValueException;
@@ -66,7 +65,8 @@ final class DiffCommand extends AbstractDumpCommand
             throw new InvalidArgumentValueException(ucfirst($type) . ' environment "' . $env . '" doesn\'t exist in config');
         }
 
-        $adapter = AdapterFactory::instance($config);
+        $adapterFactoryClass = $this->getConfig()->getAdapterFactoryClass();
+        $adapter = $adapterFactoryClass::instance($config);
         return $adapter->getStructure();
     }
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phoenix\Config;
 
+use Phoenix\Database\Adapter\AdapterFactory;
+use Phoenix\Database\Adapter\AdapterFactoryInterface;
 use Phoenix\Exception\ConfigException;
 use Phoenix\Exception\InvalidArgumentValueException;
 
@@ -20,6 +22,7 @@ final class Config
         'dependencies' => [],
         'template' => __DIR__ . '/../Templates/DefaultTemplate.phoenix',
         'indent' => '4spaces',
+        'adapter_factory_class' => AdapterFactory::class,
     ];
 
     /**
@@ -110,5 +113,13 @@ final class Config
     public function getIndent(): string
     {
         return $this->configuration['indent'];
+    }
+
+    /**
+     * @return class-string<AdapterFactoryInterface>
+     */
+    public function getAdapterFactoryClass(): string
+    {
+        return $this->configuration['adapter_factory_class'];
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -117,9 +117,14 @@ final class Config
 
     /**
      * @return class-string<AdapterFactoryInterface>
+     * @throws InvalidArgumentValueException
      */
     public function getAdapterFactoryClass(): string
     {
-        return $this->configuration['adapter_factory_class'];
+        $class = $this->configuration['adapter_factory_class'];
+        if (!is_subclass_of($class, AdapterFactoryInterface::class) && $class !== AdapterFactory::class) {
+            throw new InvalidArgumentValueException('Adapter factory class "' . $class . '" must implement ' . AdapterFactoryInterface::class);
+        }
+        return $class;
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -122,7 +122,7 @@ final class Config
     public function getAdapterFactoryClass(): string
     {
         $class = $this->configuration['adapter_factory_class'];
-        if (!is_subclass_of($class, AdapterFactoryInterface::class) && $class !== AdapterFactory::class) {
+        if (!is_subclass_of($class, AdapterFactoryInterface::class)) {
             throw new InvalidArgumentValueException('Adapter factory class "' . $class . '" must implement ' . AdapterFactoryInterface::class);
         }
         return $class;

--- a/src/Database/Adapter/AdapterFactory.php
+++ b/src/Database/Adapter/AdapterFactory.php
@@ -8,7 +8,7 @@ use PDO;
 use Phoenix\Config\EnvironmentConfig;
 use Phoenix\Exception\InvalidArgumentValueException;
 
-final class AdapterFactory
+final class AdapterFactory implements AdapterFactoryInterface
 {
     public static function instance(EnvironmentConfig $config): AdapterInterface
     {

--- a/src/Database/Adapter/AdapterFactoryInterface.php
+++ b/src/Database/Adapter/AdapterFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phoenix\Database\Adapter;
+
+use Phoenix\Config\EnvironmentConfig;
+
+interface AdapterFactoryInterface
+{
+    public static function instance(EnvironmentConfig $config): AdapterInterface;
+}

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -6,8 +6,10 @@ namespace Phoenix\Tests\Config;
 
 use Phoenix\Config\Config;
 use Phoenix\Config\EnvironmentConfig;
+use Phoenix\Database\Adapter\AdapterFactory;
 use Phoenix\Exception\ConfigException;
 use Phoenix\Exception\InvalidArgumentValueException;
+use Phoenix\Tests\Mock\Database\Adapter\MockAdapterFactory;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidFactoryInterface;
@@ -203,12 +205,11 @@ final class ConfigTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(\Phoenix\Database\Adapter\AdapterFactory::class, $config->getAdapterFactoryClass());
+        $this->assertEquals(AdapterFactory::class, $config->getAdapterFactoryClass());
     }
 
-    public function testCustomAdapterFactoryClass(): void
+    public function testInvalidAdapterFactoryClass(): void
     {
-        $customAdapterFactoryClass = 'My\Custom\AdapterFactory';
         $config = new Config([
             'migration_dirs' => [
                 'first_dir',
@@ -216,9 +217,26 @@ final class ConfigTest extends TestCase
             'environments' => [
                 'first' => [],
             ],
-            'adapter_factory_class' => $customAdapterFactoryClass,
+            'adapter_factory_class' => 'Invalid\NonExistent\Class',
         ]);
 
-        $this->assertEquals($customAdapterFactoryClass, $config->getAdapterFactoryClass());
+        $this->expectException(InvalidArgumentValueException::class);
+        $this->expectExceptionMessage('Adapter factory class "Invalid\NonExistent\Class" must implement Phoenix\Database\Adapter\AdapterFactoryInterface');
+        $config->getAdapterFactoryClass();
+    }
+
+    public function testCustomAdapterFactoryClass(): void
+    {
+        $config = new Config([
+            'migration_dirs' => [
+                'first_dir',
+            ],
+            'environments' => [
+                'first' => [],
+            ],
+            'adapter_factory_class' => MockAdapterFactory::class,
+        ]);
+
+        $this->assertEquals(MockAdapterFactory::class, $config->getAdapterFactoryClass());
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -191,4 +191,34 @@ final class ConfigTest extends TestCase
         $this->expectExceptionMessage('Dependency for type "Ramsey\Uuid\UuidFactory" not found. Register it via $configuration[\'dependencies\'][\'Ramsey\Uuid\UuidFactory\']');
         $config->getDependency(UuidFactory::class);
     }
+
+    public function testDefaultAdapterFactoryClass(): void
+    {
+        $config = new Config([
+            'migration_dirs' => [
+                'first_dir',
+            ],
+            'environments' => [
+                'first' => [],
+            ],
+        ]);
+
+        $this->assertEquals(\Phoenix\Database\Adapter\AdapterFactory::class, $config->getAdapterFactoryClass());
+    }
+
+    public function testCustomAdapterFactoryClass(): void
+    {
+        $customAdapterFactoryClass = 'My\Custom\AdapterFactory';
+        $config = new Config([
+            'migration_dirs' => [
+                'first_dir',
+            ],
+            'environments' => [
+                'first' => [],
+            ],
+            'adapter_factory_class' => $customAdapterFactoryClass,
+        ]);
+
+        $this->assertEquals($customAdapterFactoryClass, $config->getAdapterFactoryClass());
+    }
 }

--- a/tests/Mock/Database/Adapter/MockAdapterFactory.php
+++ b/tests/Mock/Database/Adapter/MockAdapterFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phoenix\Tests\Mock\Database\Adapter;
+
+use Phoenix\Config\EnvironmentConfig;
+use Phoenix\Database\Adapter\AdapterFactoryInterface;
+use Phoenix\Database\Adapter\AdapterInterface;
+
+final class MockAdapterFactory implements AdapterFactoryInterface
+{
+    public static function instance(EnvironmentConfig $config): AdapterInterface
+    {
+        throw new \RuntimeException('Mock adapter factory should not be instantiated in tests');
+    }
+}


### PR DESCRIPTION
This pull request introduces support for custom database adapter factories, allowing users to specify their own adapter factory class in the configuration. This brings greater flexibility for integrating custom database adapters. The changes include updates to the configuration handling, command usage, and related documentation, as well as tests to ensure correct behavior.

**Configuration and Extensibility:**
* Added a new `adapter_factory_class` configuration option, allowing users to specify a fully qualified class name for a custom adapter factory. The class must implement `Phoenix\Database\Adapter\AdapterFactoryInterface`, and defaults to `Phoenix\Database\Adapter\AdapterFactory`. 
* Introduced the `AdapterFactoryInterface` interface and updated the existing `AdapterFactory` to implement it, enabling custom adapter factories. 

**Command and Internal Usage:**
* Modified command classes to use the adapter factory class specified in configuration, instead of hardcoding `AdapterFactory`. 

**Dependency and Compatibility:**
* Updated `composer.json` to allow both Symfony Console v7.4 and v8.0, increasing compatibility.

**Testing:**
* Added tests for the new `adapter_factory_class` configuration, including validation of default, invalid, and custom values. Introduced a `MockAdapterFactory` for testing purposes.